### PR TITLE
refactor(all): changed to 401 on unauthorized

### DIFF
--- a/src/FE/src/app/interceptor/auth.interceptor.ts
+++ b/src/FE/src/app/interceptor/auth.interceptor.ts
@@ -22,7 +22,7 @@ export class AuthInterceptor implements HttpInterceptor {
     }
     return next.handle(request).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401 || error.status === 403) {
+        if (error.status === 401) {
           // If the user is unauthorized, redirect to the login page
           this.router.navigate(['/login']);
           this.snackbarService.openSnackBar(this.translateService.instant('ERROR_AUTHENTICATING'), false);


### PR DESCRIPTION
If JWT is invalid, wrong, or you just don't have it, backend will throw 401 unauthorized, and 403 if you're not allowed, but are authorized